### PR TITLE
Fixed page steering

### DIFF
--- a/АБВГ.123456.001 (Квантовый телепортатор)/Common/merge.part.mak
+++ b/АБВГ.123456.001 (Квантовый телепортатор)/Common/merge.part.mak
@@ -1,9 +1,9 @@
 FORM_DIR = $(wildcard ../Form)
 
 ifneq ($(FORM_DIR),)
-PAGES = $(wildcard ../Overlay/Pages/Sheet_??.pdf)
+PAGES = $(sort $(wildcard ../Overlay/Pages/Sheet_??.pdf))
 else
-PAGES = $(wildcard ../Body/Pages/Sheet_??.pdf)
+PAGES = $(sort $(wildcard ../Body/Pages/Sheet_??.pdf))
 ifeq ($(PAGES),)
 PAGES = ../Body/Body.pdf
 endif

--- a/АБВГ.123456.001 (Квантовый телепортатор)/Common/overlay.mak
+++ b/АБВГ.123456.001 (Квантовый телепортатор)/Common/overlay.mak
@@ -1,4 +1,4 @@
-PAGES          = $(addprefix Pages/,$(notdir $(wildcard ../Body/Pages/Sheet_??.pdf)))
+PAGES          = $(addprefix Pages/,$(notdir $(sort $(wildcard ../Body/Pages/Sheet_??.pdf))))
 
 .PHONY : pages_files
 

--- a/АБВГ.123456.001 (Квантовый телепортатор)/Common/svg.mak
+++ b/АБВГ.123456.001 (Квантовый телепортатор)/Common/svg.mak
@@ -1,6 +1,6 @@
 PAGES_DIR     = Pages
 
-SEP_PAGES    := $(patsubst %.svg,$(PAGES_DIR)/%.pdf,$(wildcard *.svg))
+SEP_PAGES    := $(patsubst %.svg,$(PAGES_DIR)/%.pdf,$(sort $(wildcard *.svg)))
 
 MERGED_PAGES  = $(PAGES_DIR)/merged.pdf
 


### PR DESCRIPTION
GNU make wildcard no longer gives sorted output:
https://stackoverflow.com/questions/40558385/gnu-make-wildcard-no-longer-gives-sorted-output-is-there-any-control-switch

Что приводило к перемешиванию рамок в документе
