### PR TITLE
Problem with inkscape

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.pdf
+data
+form
+overlay

--- a/document_builder.py
+++ b/document_builder.py
@@ -5,6 +5,8 @@ from typing import List, Tuple
 from shutil import rmtree, copyfile
 from multiprocessing.pool import ThreadPool
 from hashlib import md5
+import cairosvg
+import os
 
 from common import print, check_call
 
@@ -82,10 +84,8 @@ class DocumentBuilder(ABC):
                 target_mtime = stat(path_join(self.document_dir, pdf_file_path)).st_mtime_ns
                 if source_mtime < target_mtime:
                     print(f'File "{pdf_file_path}" is up to date.')
-                    return
-            # dbus-run-session is required due to the following issue:
-            # https://gitlab.com/inkscape/inkscape/-/issues/294
-            check_call(['dbus-run-session', 'inkscape', '--export-pdf', pdf_file_path, svg_file_path], cwd=self.document_dir)
+                    return           
+            cairosvg.svg2pdf(url= path_join(self.document_dir , svg_file_path), write_to=path_join(self.document_dir , pdf_file_path) )
 
         print('Converting SVG files to corresponding PDF ones ...')
         svg_files = []

--- a/document_builder.py
+++ b/document_builder.py
@@ -5,8 +5,7 @@ from typing import List, Tuple
 from shutil import rmtree, copyfile
 from multiprocessing.pool import ThreadPool
 from hashlib import md5
-import cairosvg
-import os
+from cairosvg import svg2pdf
 
 from common import print, check_call
 
@@ -85,7 +84,7 @@ class DocumentBuilder(ABC):
                 if source_mtime < target_mtime:
                     print(f'File "{pdf_file_path}" is up to date.')
                     return           
-            cairosvg.svg2pdf(url= path_join(self.document_dir , svg_file_path), write_to=path_join(self.document_dir , pdf_file_path) )
+            svg2pdf(url= path_join(self.document_dir , svg_file_path), write_to=path_join(self.document_dir , pdf_file_path) )
 
         print('Converting SVG files to corresponding PDF ones ...')
         svg_files = []


### PR DESCRIPTION
В новой версии inkscape нет флага --export-pdf, поэтому лучшим решением будет использовать библиотеку python [CairoSVG](https://cairosvg.org/), не завбыв её установить:

pip3 install cairosvg

На выходе получается отлично читаемый векторный pdf с нормальным межсимвольным расстоянием

