### PR TITLE
Ошибка при генерировании перечня

### DIFF
--- a/build.py
+++ b/build.py
@@ -13,8 +13,8 @@ from re import compile
 from document_builder import SpecificationBuilder, RegisterBuilder, ListOfElementsBuilder, TextDocumentBuilder, DocumentBuilderException
 from common import print, check_call
 
-project_pattern = compile(r'^[А-Я]{4}\.\d{6}\.\d{3} \(.*\)$')
-document_pattern = compile(r'^[А-Я]{4}\.\d{6}\.\d{3} ((ВП|ПЭ3|РЭ) )?\(.*\)$')
+project_pattern = compile(r'^[А-Я]{4}[-.]{1}\d{2,}\.\d{3,}[0-9.]{0,} \(.*\)$')
+document_pattern = compile(r'^[А-Я]{4}[-.]{1}\d{2,}\.\d{3,}[0-9.]{0,} ((ВП|ПЭ3|РЭ) )?\(.*\)$')
 
 
 def check_prerequisites():

--- a/tools/apps/listofelgen/listofelgen.cxx
+++ b/tools/apps/listofelgen/listofelgen.cxx
@@ -212,14 +212,32 @@ int main(int argc, char** argv)
         lines_per_page--;
         y += line_height;
 
+		fprintf(stderr, " Page %d line %d  in eof %d out file %d\n", page_num, lines_per_page, in_file.eof(),  out_file);
+		
         if ((lines_per_page == 0) || (in_file.eof())) {
             page_num++;
             page.end(out_file);
             fclose(out_file);
             out_file = nullptr;
-        }
+            fprintf(stderr, " Page %d done  \n", page_num - 1);
+        }    
+       
 
     } while (!in_file.eof());
+    
+    
+    if (out_file != nullptr){
+		
+		page.end(out_file);
+        fclose(out_file);
+        out_file = nullptr;
+        fprintf(stderr, __FILE__":%d Page %d done  \n", __LINE__,  page_num - 1);
+		
+	}
+    
+    
+    fprintf(stderr, "Ex Page %d line %d  in eof %d out file %d\n", page_num, lines_per_page, in_file.eof(),  out_file);
+    
 
     return 0;
 }


### PR DESCRIPTION
При редактировании файла перечня элементов у меня возникла проблемма - в последнем сгенерированном svg файле перестал закрываться тег </svg> и, соответственно, файл стал воприниматься битым (OS debian, gcc 10.2.0, g++ 10.2.0, clang 9.0.1-13).

В ходе вывода диагностических сообщений удалось локализовать проблемму - игнорирование конца выходного файла (in_file.eof()), причём while конец цикла видел. На скорую руку добавил после завершения цикла проверку нулевого указателя и дописью конца файла, если он ещё открыт. Файл странный прилагается. А вот лог по диагностическим сообщениям с ним, из которого видно, что последняя картинка не завершается:

 ```
Page 1 line 28  in eof 0 out file 264692208
 Page 1 line 27  in eof 0 out file 264692208
 Page 1 line 26  in eof 0 out file 264692208
 Page 1 line 25  in eof 0 out file 264692208
 Page 1 line 24  in eof 0 out file 264692208
 Page 1 line 23  in eof 0 out file 264692208
 Page 1 line 22  in eof 0 out file 264692208
 Page 1 line 21  in eof 0 out file 264692208
 Page 1 line 20  in eof 0 out file 264692208
 Page 1 line 19  in eof 0 out file 264692208
 Page 1 line 18  in eof 0 out file 264692208
 Page 1 line 17  in eof 0 out file 264692208
 Page 1 line 16  in eof 0 out file 264692208
 Page 1 line 15  in eof 0 out file 264692208
 Page 1 line 14  in eof 0 out file 264692208
 Page 1 line 13  in eof 0 out file 264692208
 Page 1 line 12  in eof 0 out file 264692208
 Page 1 line 11  in eof 0 out file 264692208
 Page 1 line 10  in eof 0 out file 264692208
 Page 1 line 9  in eof 0 out file 264692208
 Page 1 line 8  in eof 0 out file 264692208
 Page 1 line 7  in eof 0 out file 264692208
 Page 1 line 6  in eof 0 out file 264692208
 Page 1 line 5  in eof 0 out file 264692208
 Page 1 line 4  in eof 0 out file 264692208
 Page 1 line 3  in eof 0 out file 264692208
 Page 1 line 2  in eof 0 out file 264692208
 Page 1 line 1  in eof 0 out file 264692208
 Page 1 line 0  in eof 0 out file 264692208
 Page 1 done  
 Page 2 line 31  in eof 0 out file 264692208
 Page 2 line 30  in eof 0 out file 264692208
 Page 2 line 29  in eof 0 out file 264692208
 Page 2 line 28  in eof 0 out file 264692208
 Page 2 line 27  in eof 0 out file 264692208
 Page 2 line 26  in eof 0 out file 264692208
 Page 2 line 25  in eof 0 out file 264692208
Ex Page 2 line 24  in eof 1 out file 264692208
3 sheet(s) has/have been generated.
Generating form sheets ...
Executing: /home/igorbunov/PROJECTS/latex/gost_forms/tools/apps/formgen/formgen -i ../form.kxg -p 3 (in /home/igorbunov/PROJECTS/latex/gost_forms/АБВГ.123456.001 (Квантовый телепортатор)/АБВГ.123456.001 ПЭ3 (Перечень элементов)/form)
Converting SVG files to corresponding PDF ones ...
Critical error: no element found: line 67, column 0
```

Также отредактировал шаблон имён проектов, сохранив совместимость с имеющимся, тк у нас на предприятии принят следующий формат имён:

АБВГ-12.123 (Варп двигатель)
АБВГ-12.123.123 (Модуль межгалактической связи)


[data.txt](https://github.com/kutelev/gost_forms/files/5163462/data.txt)
